### PR TITLE
Fix for quotation marks in path elements

### DIFF
--- a/IoTAPIPortingTool/Program.cs
+++ b/IoTAPIPortingTool/Program.cs
@@ -144,7 +144,10 @@ namespace IoTAPIPortingTool
             {
                 foreach (var s in paths)
                 {
-                    var pth = Path.Combine(s, "dumpbin.exe");
+                    // some path elements may have quotation marks around them (useless, but legal)
+                    var spath=s.Trim('\"');
+
+                    var pth = Path.Combine(spath, "dumpbin.exe");
                     if (File.Exists(pth))
                     {
                         haveDeveloperPrompt = true;


### PR DESCRIPTION
Adding quotation marks (") around path elements that contains spaces is
not required (the semicolon is used as separator between path elements),
but is supported by command prompt and environment configuration in
control panel. This change will prevent the app from throwing an
"Invalid characters in path" exception when one of PATH's elements is
wrapped in double quotes.