### PR TITLE
invalid SQL syntax

### DIFF
--- a/IoTAPIPortingTool/Program.cs
+++ b/IoTAPIPortingTool/Program.cs
@@ -21,7 +21,7 @@ namespace IoTAPIPortingTool
             WindowsIoTNonUAP = 4,
         }
 
-        private const string functionSelect = "SELECT * FROM FUNCTION WHERE F_NAME = '{0}';";
+        private const string functionSelect = "SELECT * FROM FUNCTION WHERE F_NAME = '{0}' ";
         private const string functionSelectWithDll = functionSelect + "AND F_DLL_NAME = '{1}';";
         private const string selectDll = "SELECT * FROM DLL WHERE D_NAME = '{0}'";
 


### PR DESCRIPTION
When running this command line application, there is an error from SQL lite that indicates that the syntax of the functionSelectWithDll query is invalid.  Removing the extra terminal semicolon from the functionSelect query fixes the error
