### PR TITLE
Valid "OS" API rejected even when UAP is off

### DIFF
--- a/IoTAPIPortingTool/Program.cs
+++ b/IoTAPIPortingTool/Program.cs
@@ -344,13 +344,16 @@ namespace IoTAPIPortingTool
                                 var functionExists = dataReader.Read();
                                 dataReader.Close();
 
-                                apiDBCommand.CommandText = string.Format(apiQuery, functionName);
-                                dataReader = apiDBCommand.ExecuteReader();
+                                if (isUAP)
+                                {
+                                    apiDBCommand.CommandText = string.Format(apiQuery, functionName);
+                                    dataReader = apiDBCommand.ExecuteReader();
 
-                                functionExists &= dataReader.Read();
+                                    functionExists &= dataReader.Read();
 
-                                dataReader.Close();
-
+                                    dataReader.Close();
+                                }
+                                
                                 if (!functionExists)
                                 {
                                     invalidFunctionCount++;


### PR DESCRIPTION
The command line -os turns off UAP checks, yet line 349 reject functions when it should not

Proposed change fixes this, and now Operating System (non UAP) API is correctly found to be valid

Without this change the following functions are rejected:

> ARM\Release\MemoryStatus.exe  vcruntime140.dll    __std_terminate
> ARM\Release\MemoryStatus.exe  vcruntime140.dll    _purecall
> ARM\Release\MemoryStatus.exe  vcruntime140.dll    __C_specific_handler
> ARM\Release\MemoryStatus.exe  vcruntime140.dll    __std_exception_copy
> ARM\Release\MemoryStatus.exe  vcruntime140.dll    __std_exception_destroy
> ARM\Release\MemoryStatus.exe  vcruntime140.dll    __CxxFrameHandler3
> ARM\Release\MemoryStatus.exe  vcruntime140.dll    _CxxThrowException

Since I am running the IoTAPIPortingTool against the sample MemoryStatus application, and that it runs on the RaspBerry Pi 2B running Microsoft Windows 10 IoT Core, I would expect that all the functions would pass the scan.

This change feels wrong though, perhaps check the DLL name for a starting text of vcruntime would be better?  However when this alternative check is performed, other perfectly valid functions fail: WaitForMultipleObjects and many others.
